### PR TITLE
Fix ShareImage to strip HTML tags from album text

### DIFF
--- a/frontend/src/Components/Misc/ShareImage.tsx
+++ b/frontend/src/Components/Misc/ShareImage.tsx
@@ -16,6 +16,12 @@ export default function ShareImage({albums}: ShareImageProps) {
   const imageRefs = useRef<HTMLDivElement[]>([]);
   const { setCurrentComponent } = useComponent();
 
+  const stripHtmlTags = (html: string): string => {
+    const tmp = document.createElement("div");
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || "";
+  };
+
   const handleDownload = async () => {
     const zip = new JSZip();
     for (let i = 0; i < albums.length; i++) {
@@ -114,7 +120,7 @@ export default function ShareImage({albums}: ShareImageProps) {
                 paddingBottom: '20px',
                     }}
             >
-              {album.text}
+              {stripHtmlTags(album.text)}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Add stripHtmlTags helper function to properly handle album text
from database that may contain HTML formatting. The function uses
DOM API to safely extract plain text content for social media images.